### PR TITLE
Cast AudioBufferChannelView to Float32Array

### DIFF
--- a/Sources/aura/types/AudioBuffer.hx
+++ b/Sources/aura/types/AudioBuffer.hx
@@ -56,7 +56,7 @@ class AudioBuffer {
 	}
 }
 
-abstract AudioBufferChannelView(Float32Array) from Float32Array {
+abstract AudioBufferChannelView(Float32Array) from Float32Array to Float32Array {
 	public function new(size: Int) {
 		this = new Float32Array(size);
 	}


### PR DESCRIPTION
Fixes:
`.../Subprojects/aura/Sources/aura/channels/ResamplingAudioChannel.hx:61: characters 67-89 : aura.types.AudioBufferChannelView should be kha.arrays.Float32Array
../Subprojects/aura/Sources/aura/channels/ResamplingAudioChannel.hx:61: characters 67-89 : ... For function argument 'sourceData'`
