### PR TITLE
Add 3D audio for desktop and mobile browser with compressed audio

### DIFF
--- a/Sources/aura/dsp/panner/StereoPanner.hx
+++ b/Sources/aura/dsp/panner/StereoPanner.hx
@@ -64,6 +64,8 @@ class StereoPanner extends Panner {
 
 		sendMessage({ id: StereoPannerMessageID.PVolumeLeft, data: Math.sqrt(~balance) });
 		sendMessage({ id: StereoPannerMessageID.PVolumeRight, data: Math.sqrt(balance) });
+		handle.channel.sendMessage({ id: ChannelMessageID.PVolumeLeft, data: Math.sqrt(~balance) });
+		handle.channel.sendMessage({ id: ChannelMessageID.PVolumeRight, data: Math.sqrt(balance) });
 	}
 
 	public inline function getBalance(): Balance {

--- a/Sources/aura/threading/Message.hx
+++ b/Sources/aura/threading/Message.hx
@@ -25,6 +25,9 @@ class ChannelMessageID extends MessageID {
 	final PPitch;
 	final PDopplerRatio;
 	final PDstAttenuation;
+
+	final PVolumeLeft;
+	final PVolumeRight;
 }
 
 class DSPMessageID extends MessageID {


### PR DESCRIPTION
This adds support for 3D audio on both desktop and mobile browsers, but depends on [this PR](https://github.com/armory3d/Kha/pull/4) to work on mobile.