### PR TITLE
General HTML5 channel fixes

### DIFF
--- a/Sources/aura/channels/Html5StreamChannel.hx
+++ b/Sources/aura/channels/Html5StreamChannel.hx
@@ -10,6 +10,7 @@ import js.html.audio.ChannelMergerNode;
 import js.html.audio.GainNode;
 import js.html.audio.MediaElementAudioSourceNode;
 import js.html.URL;
+import js.lib.ArrayBuffer;
 
 import kha.SystemImpl;
 import kha.js.MobileWebAudio;
@@ -59,7 +60,7 @@ class Html5StreamChannel extends BaseChannel {
 		source = audioContext.createMediaElementSource(audioElement);
 
 		final mimeType = #if kha_debug_html5 "audio/ogg" #else "audio/mp4" #end;
-		final soundData: js.lib.ArrayBuffer = sound.compressedData.getData();
+		final soundData: ArrayBuffer = sound.compressedData.getData();
 		final blob = new js.html.Blob([soundData], {type: mimeType});
 
 		// TODO: if removing channels, use revokeObjectUrl() ?
@@ -77,8 +78,8 @@ class Html5StreamChannel extends BaseChannel {
 
 		source.connect(splitter);
 
-		// The sound data needs to be decoded because `sounds.channels` returns `0`.
-		audioContext.decodeAudioData(soundData, function (buffer) {
+		final soundDataClone: ArrayBuffer = soundData.slice(0); // HACK: the sound data needs to be cloned to prevent errors when a scene is reloaded.
+		audioContext.decodeAudioData(soundDataClone, function (buffer) { // HACK: the sound data needs to be decoded because `sound.channels` returns `0`.
 			// TODO: add more cases for Quad and 5.1 ? - https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#audio_channels
 			switch (buffer.numberOfChannels) {
 				case 1:

--- a/Sources/aura/channels/Html5StreamChannel.hx
+++ b/Sources/aura/channels/Html5StreamChannel.hx
@@ -78,8 +78,20 @@ class Html5StreamChannel extends BaseChannel {
 
 		source.connect(splitter);
 
-		final soundDataClone: ArrayBuffer = soundData.slice(0); // HACK: the sound data needs to be cloned to prevent errors when a scene is reloaded.
-		audioContext.decodeAudioData(soundDataClone, function (buffer) { // HACK: the sound data needs to be decoded because `sound.channels` returns `0`.
+		/*
+			HACK: `sound.channels` always returns 0, so decode the sound data...
+
+			HACK: decodeAudioData() detaches the array buffer but requires a
+			non-detached buffer, so for each call make a clone to ensure that
+			soundData is never detached and can still be used by other channels
+			or other code.
+
+			TODO: we could probably just read into the file header ourselves
+			to get the channel count, this should be much faster and there's no
+			need to clone the buffer then.
+		*/
+		final soundDataClone: ArrayBuffer = soundData.slice(0);
+		audioContext.decodeAudioData(soundDataClone, function (buffer) {
 			// TODO: add more cases for Quad and 5.1 ? - https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#audio_channels
 			switch (buffer.numberOfChannels) {
 				case 1:
@@ -179,8 +191,10 @@ class Html5StreamChannel extends BaseChannel {
 	}
 
 	/**
-	 * For manual clean up when `BaseChannelHandle.setMixChannel(null)` is used. Useful when changing scenes.
-	 * Usage: `#if (kha_html5 || kha_debug_html5) untyped cast(@:privateAccess BaseChannelHandle.channel).cleanUp(); #end`.
+		For manual clean up when `BaseChannelHandle.setMixChannel(null)` is used.
+		Useful e.g. when changing scenes in Armory.
+
+		Usage: `#if (kha_html5 || kha_debug_html5) untyped cast(@:privateAccess BaseChannelHandle.channel).cleanUp(); #end`.
 	**/
 	public function cleanUp() {
 		source.disconnect();
@@ -312,8 +326,10 @@ class Html5MobileStreamChannel extends BaseChannel {
 	}
 
 	/**
-	 * For manual clean up when `BaseChannelHandle.setMixChannel(null)` is used. Useful when changing scenes.
-	 * Usage: `#if (kha_html5 || kha_debug_html5) untyped cast(@:privateAccess BaseChannelHandle.channel).cleanUp(); #end`.
+		For manual clean up when `BaseChannelHandle.setMixChannel(null)` is used.
+		Useful e.g. when changing scenes in Armory.
+
+		Usage: `#if (kha_html5 || kha_debug_html5) untyped cast(@:privateAccess BaseChannelHandle.channel).cleanUp(); #end`.
 	**/
 	public function cleanUp() {
 		@:privateAccess khaChannel.gain.disconnect();


### PR DESCRIPTION
- **Prevent HTML5 audio error when a scene is reloaded**
In `HTML5StreamChannel`, if the sound data isn't cloned and the channel is reloaded, the browser throws this error in [this line](https://github.com/MoritzBrueckner/aura/pull/16/commits/8710ca9a395efb2704a797877600dcfa2dbeb77c#diff-6080898bcb1551a211b2e41a1d870d691f386eac8405825ff2705914a90ddb17L81):
```
Html5StreamChannel.hx:81 Uncaught TypeError: Cannot perform ArrayBuffer.prototype.slice on a detached ArrayBuffer
    at ArrayBuffer.slice (<anonymous>)
    at new aura_channels_Html5StreamChannel (Html5StreamChannel.hx:81:39)
    at aura_Aura.createCompBufferChannel (Aura.hx:318:91)
    at HoverCar.hx:62:24
    at iron_App.update (App.hx:77:30)
    at kha_TimeTask.task (Scheduler.hx:433:4)
    at kha_Scheduler.executeTimeTasks (Scheduler.hx:317:34)
    at kha_Scheduler.executeFrame (Scheduler.hx:270:4)
    at animate (SystemImpl.hx:565:4)
```

- **Add function to clean up unused audio channels in HTML5**
When Aura is already loaded and `setMixChannel(null)` is used, the audio in HTML5 kept in memory and playing. The new `cleanUp()` function should be used after `setMixChannel(null)` in HTML5 builds to completely remove the channels.