### PR TITLE
General fixes

### DIFF
--- a/Sources/aura/Aura.hx
+++ b/Sources/aura/Aura.hx
@@ -142,17 +142,17 @@ class Aura {
 
 				#if (kha_html5 || kha_debug_html5)
 					if (kha.SystemImpl.mobile) {
-				#end
 						// Mobile web audio channels are always decoded and
 						// the channel count is set by Kha afterwards
 						onChannelCountInitialized();
-				#if (kha_html5 || kha_debug_html5)
 					}
 					else {
 						// HACK: Kha does not set sound.channel for compressed
 						// sounds on non-mobile html5 targets, so do it manually
 						aura.channels.Html5StreamChannel.initializeChannelCount(sound, onChannelCountInitialized);
 					}
+				#else
+					onChannelCountInitialized();
 				#end
 			}, (error: kha.AssetError) -> { onLoadingError(error, failed, soundName); });
 		}

--- a/Sources/aura/Aura.hx
+++ b/Sources/aura/Aura.hx
@@ -129,9 +129,8 @@ class Aura {
 					}
 				#end
 
-				count++;
-
 				function onChannelCountInitialized() {
+					count++;
 					if (onProgress != null) {
 						onProgress(count, length, soundName);
 					}
@@ -143,17 +142,17 @@ class Aura {
 
 				#if (kha_html5 || kha_debug_html5)
 					if (kha.SystemImpl.mobile) {
+				#end
 						// Mobile web audio channels are always decoded and
 						// the channel count is set by Kha afterwards
 						onChannelCountInitialized();
+				#if (kha_html5 || kha_debug_html5)
 					}
 					else {
 						// HACK: Kha does not set sound.channel for compressed
 						// sounds on non-mobile html5 targets, so do it manually
 						aura.channels.Html5StreamChannel.initializeChannelCount(sound, onChannelCountInitialized);
 					}
-				#else
-					onChannelCountInitialized();
 				#end
 			}, (error: kha.AssetError) -> { onLoadingError(error, failed, soundName); });
 		}

--- a/Sources/aura/channels/Html5StreamChannel.hx
+++ b/Sources/aura/channels/Html5StreamChannel.hx
@@ -187,7 +187,7 @@ class Html5StreamChannel extends BaseChannel {
 
 		Usage: `#if (kha_html5 || kha_debug_html5) untyped cast(@:privateAccess BaseChannelHandle.channel).cleanUp(); #end`.
 	**/
-	public function cleanUp() {
+	@:keep public function cleanUp() {
 		source.disconnect();
 		splitter.disconnect();
 		leftGain.disconnect();
@@ -323,7 +323,7 @@ class Html5MobileStreamChannel extends BaseChannel {
 
 		Usage: `#if (kha_html5 || kha_debug_html5) untyped cast(@:privateAccess BaseChannelHandle.channel).cleanUp(); #end`.
 	**/
-	public function cleanUp() {
+	@:keep public function cleanUp() {
 		@:privateAccess khaChannel.gain.disconnect();
 		@:privateAccess khaChannel.source.disconnect();
 		splitter.disconnect();


### PR DESCRIPTION
Changes:
- only count the audio files that are being initialized by `aura.channels.Html5StreamChannel.initializeChannelCount`. This prevents the audio being count twice when Armory generates `mp4` and `ogg` files in the same build
- keep the `cleanUp` function from `Html5StreamChannel` on DCE